### PR TITLE
Implement all TODO items: TensorBoard, resume training, argparse, multi-GPU

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+## Cursor Cloud specific instructions
+
+### Project overview
+Fast-SCNN is a PyTorch implementation of the Fast Semantic Segmentation Network. See `readme.md` for architecture details.
+
+### Key entry points
+- `train.py` — trains on a dataset (defaults to VOC2012, 21 classes, 320x320 input)
+- `test.py` — runs inference on video/images (requires trained weights at `save/train_1999.pth`)
+- `models/fastscnn.py` — model definition; runnable standalone as an FPS benchmark
+
+### Dependencies
+The `requirements.txt` pins very old versions (2020-era) that are incompatible with Python 3.12. Install modern versions instead:
+```
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+pip install numpy opencv-python-headless tensorboardX tqdm
+```
+- `apex` in `requirements.txt` is **not imported** anywhere and can be safely skipped.
+- Use `opencv-python-headless` (not `opencv-python`) in headless/CI environments.
+
+### Known compatibility issues
+- `utils/transform.py` uses `collections.Iterable`, which was removed in Python 3.10+. The fix is `collections.abc.Iterable`. This affects data augmentation transforms used during training.
+- `utils/common.py` `intersectionAndUnionGPU()` calls `.cuda()` unconditionally. On CPU-only environments, training/validation will fail at that call.
+- `test.py` calls `.cuda()` directly and requires a GPU with trained weights to run.
+
+### Running without a GPU
+The model itself (`FastSCNN`) works on CPU. You can instantiate and do forward passes:
+```python
+from models.fastscnn import FastSCNN
+model = FastSCNN(21, aux=True)
+model.eval()
+out = model(torch.randn(1, 3, 320, 320))
+```
+Full training (`train.py`) and inference (`test.py`) scripts assume CUDA and a dataset/weights on disk.
+
+### No linter or test suite
+This repository has no configured linter, formatter, or automated test suite.

--- a/readme.md
+++ b/readme.md
@@ -53,10 +53,10 @@ dataset
 
 ## TODO
 - [x] Training & Validate functions
-- [ ] Tensorboard 记录
-- [ ] resume training 脚本
-- [ ] VOC2012数据集训练脚本
-- [ ] 多GPU训练
+- [x] Tensorboard 记录
+- [x] resume training 脚本
+- [x] VOC2012数据集训练脚本
+- [x] 多GPU训练
 ## Support Me
 If you want to speedup my progress, please support me.  
 <a href="https://www.buymeacoffee.com/winafoxq"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=winafoxq&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>

--- a/train.py
+++ b/train.py
@@ -31,16 +31,63 @@ from utils import dataset, transform, common
 from models import fastscnn
 from loss import diceloss
 
-numClasses = 21
-dataRoot = 'voc2012'
-trainList = 'voc2012/train.txt'
-valList = 'voc2012/val.txt'
-globalEpoch = 2000
-baseLr = 0.01
-inputHW = [320, 320]
 
 cv2.ocl.setUseOpenCL(True)
 cv2.setNumThreads(32)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Fast-SCNN Training')
+    parser.add_argument('--data-root', type=str, default='voc2012',
+                        help='path to dataset root directory')
+    parser.add_argument('--train-list', type=str, default=None,
+                        help='path to train list file (default: <data-root>/train.txt)')
+    parser.add_argument('--val-list', type=str, default=None,
+                        help='path to val list file (default: <data-root>/val.txt)')
+    parser.add_argument('--num-classes', type=int, default=21,
+                        help='number of segmentation classes (default: 21 for VOC2012)')
+    parser.add_argument('--epochs', type=int, default=2000,
+                        help='total training epochs')
+    parser.add_argument('--base-lr', type=float, default=0.01,
+                        help='initial learning rate')
+    parser.add_argument('--batch-size', type=int, default=160,
+                        help='training batch size')
+    parser.add_argument('--val-batch-size', type=int, default=4,
+                        help='validation batch size')
+    parser.add_argument('--input-h', type=int, default=320,
+                        help='input image height')
+    parser.add_argument('--input-w', type=int, default=320,
+                        help='input image width')
+    parser.add_argument('--num-workers', type=int, default=32,
+                        help='number of data loading workers')
+    parser.add_argument('--save-dir', type=str, default='save',
+                        help='directory for saving checkpoints')
+    parser.add_argument('--save-freq', type=int, default=20,
+                        help='save checkpoint every N epochs')
+    parser.add_argument('--resume', type=str, default=None,
+                        help='path to checkpoint to resume training from')
+    parser.add_argument('--log-dir', type=str, default='runs',
+                        help='TensorBoard log directory')
+    parser.add_argument('--multigpu', action='store_true',
+                        help='use nn.DataParallel for multi-GPU training')
+    parser.add_argument('--dist', action='store_true',
+                        help='use DistributedDataParallel for multi-GPU training')
+    parser.add_argument('--local_rank', type=int, default=0,
+                        help='local rank for distributed training (set by torch.distributed.launch)')
+    parser.add_argument('--momentum', type=float, default=0.9,
+                        help='SGD momentum')
+    parser.add_argument('--weight-decay', type=float, default=0.0001,
+                        help='SGD weight decay')
+    parser.add_argument('--aux-weight', type=float, default=0.4,
+                        help='weight for auxiliary loss')
+    args = parser.parse_args()
+
+    if args.train_list is None:
+        args.train_list = os.path.join(args.data_root, 'train.txt')
+    if args.val_list is None:
+        args.val_list = os.path.join(args.data_root, 'val.txt')
+
+    return args
 
 
 def poly_learning_rate(base_lr, curr_iter, max_iter, power=0.9):
@@ -72,8 +119,8 @@ def getMeanStd():
     std = [item * value_scale for item in std]
     return mean, std
 
-def prepareDataset(rootpath, trainlist, vallist, mean, std):
-    # prepare dataset transform before training
+def prepareDataset(args, mean, std):
+    inputHW = [args.input_h, args.input_w]
     trans = transform.Compose([
         transform.RandScale([0.5,2]),
         transform.RandomGaussianBlur(),
@@ -82,83 +129,80 @@ def prepareDataset(rootpath, trainlist, vallist, mean, std):
         transform.ToTensor(),
         transform.Normalize(mean=mean,std=std)
     ])
-    # val transform
     valTrans = transform.Compose([
         transform.Crop(inputHW, crop_type='center', padding=mean, ignore_label=255),
         transform.ToTensor(),
         transform.Normalize(mean=mean, std=std)
     ])
 
-    # training data
-    trainData = dataset.SemData(split='train', data_root=rootpath, data_list=trainlist, transform=trans)
-    trainDataLoader = torch.utils.data.DataLoader(trainData,
-                                                batch_size=160,
-                                                shuffle=True,
-                                                num_workers=32,
-                                                pin_memory=True,
-                                                drop_last=True)
+    trainData = dataset.SemData(split='train', data_root=args.data_root,
+                                data_list=args.train_list, transform=trans)
+    train_sampler = None
+    if args.dist:
+        train_sampler = torch.utils.data.distributed.DistributedSampler(trainData)
 
-    # val data
-    valData = dataset.SemData(split='val', data_root=rootpath, data_list=vallist, transform=valTrans)
-    valDataLoader = torch.utils.data.DataLoader(valData,
-                                                batch_size=4,
-                                                shuffle=False,
-                                                num_workers=4,
-                                                pin_memory=True)
-    # return datasets
-    return trainDataLoader, valDataLoader
+    trainDataLoader = torch.utils.data.DataLoader(
+        trainData,
+        batch_size=args.batch_size,
+        shuffle=(train_sampler is None),
+        num_workers=args.num_workers,
+        pin_memory=True,
+        drop_last=True,
+        sampler=train_sampler)
 
-def subTrain(model, optimizer, criterion, dataLoader, currentepoch, maxIter, device):
-    # set to train mode to enable dropout and bn
+    valData = dataset.SemData(split='val', data_root=args.data_root,
+                              data_list=args.val_list, transform=valTrans)
+    valDataLoader = torch.utils.data.DataLoader(
+        valData,
+        batch_size=args.val_batch_size,
+        shuffle=False,
+        num_workers=4,
+        pin_memory=True)
+
+    return trainDataLoader, valDataLoader, train_sampler
+
+def subTrain(model, optimizer, criterion, dataLoader, currentepoch, maxIter, device, args):
     model.train()
 
     intersectionMeter = common.AverageMeter()
     unionMeter = common.AverageMeter()
     targetMeter = common.AverageMeter()
     lossMeter = common.AverageMeter()
-    
+
     for i, (x, y) in enumerate(dataLoader):
         x = x.to(device)
         y = y.to(device)
-        
+
         out = model(x)
         mainLoss = criterion(out[0], y)
         auxLoss = criterion(out[1], y)
 
-        # whole loss
-        loss = 0.4*auxLoss + mainLoss
+        loss = args.aux_weight * auxLoss + mainLoss
         lossMeter.update(loss.item(), x.shape[0])
-        #print('loss is:', loss.item())
 
-        # step
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
 
-        # ajust lr
         curIter = currentepoch * len(dataLoader) + i + 1
-        newLr = poly_learning_rate(baseLr, curIter, maxIter)
+        newLr = poly_learning_rate(args.base_lr, curIter, maxIter)
         optimizer.param_groups[0]['lr'] = newLr
 
-        # compute IoU/accuracy
         result = out[0].max(1)[1]
-        intersection, union, target = common.intersectionAndUnionGPU(result, y, numClasses, 255)
+        intersection, union, target = common.intersectionAndUnion(result, y, args.num_classes, 255)
         intersection, union, target = intersection.cpu().numpy(), union.cpu().numpy(), target.cpu().numpy()
-        ## update meter
         intersectionMeter.update(intersection), unionMeter.update(union), targetMeter.update(target)
-    
-    # after every epoch, print the log    
-    IoU = intersectionMeter.sum/(unionMeter.sum + 1e-10)
-    accuracy = intersectionMeter.sum/(targetMeter.sum + 1e-10)
-    
-    print(f'[{currentepoch}/{globalEpoch}] loss:',lossMeter.avg)
-    '''
-    for i in range(numClasses):
-        print(f'training Class_{i} IoU: {IoU[i]}, acc: {accuracy[i]}')
-    '''
 
-def subVal(model, criterion, dataLoader, device):
-    # set to eval mode
+    IoU = intersectionMeter.sum/(unionMeter.sum + 1e-10)
+    mIoU = IoU.mean()
+    accuracy = intersectionMeter.sum/(targetMeter.sum + 1e-10)
+    mAcc = accuracy.mean()
+
+    print(f'[{currentepoch}/{args.epochs}] loss:',lossMeter.avg)
+
+    return lossMeter.avg, mIoU, mAcc
+
+def subVal(model, criterion, dataLoader, device, args):
     model.eval()
 
     intersectionMeter = common.AverageMeter()
@@ -166,60 +210,118 @@ def subVal(model, criterion, dataLoader, device):
     targetMeter = common.AverageMeter()
     lossMeter = common.AverageMeter()
 
-    for i, (x, y) in enumerate(dataLoader):
-        x = x.to(device)
-        y = y.to(device)
-        
-        out = model(x)
-        mainLoss = criterion(out[0], y)
-        
-        # update val loss
-        lossMeter.update(mainLoss.item(), x.shape[0])
+    with torch.no_grad():
+        for i, (x, y) in enumerate(dataLoader):
+            x = x.to(device)
+            y = y.to(device)
 
-        # compute IoU/accuracy
-        result = out[0].max(1)[1]
-        intersection, union, target = common.intersectionAndUnionGPU(result, y, numClasses, 255)
-        intersection, union, target = intersection.cpu().numpy(), union.cpu().numpy(), target.cpu().numpy()
-        ## update meter
-        intersectionMeter.update(intersection), unionMeter.update(union), targetMeter.update(target)
-    
-    # show the log
+            out = model(x)
+            mainLoss = criterion(out[0], y)
+
+            lossMeter.update(mainLoss.item(), x.shape[0])
+
+            result = out[0].max(1)[1]
+            intersection, union, target = common.intersectionAndUnion(result, y, args.num_classes, 255)
+            intersection, union, target = intersection.cpu().numpy(), union.cpu().numpy(), target.cpu().numpy()
+            intersectionMeter.update(intersection), unionMeter.update(union), targetMeter.update(target)
+
     IoU = intersectionMeter.sum/(unionMeter.sum + 1e-10)
+    mIoU = IoU.mean()
     accuracy = intersectionMeter.sum/(targetMeter.sum + 1e-10)
+    mAcc = accuracy.mean()
+
     print(f'val loss:',lossMeter.avg)
-    for i in range(numClasses):
+    for i in range(args.num_classes):
         print('Class_'+str(i)+' IoU:',IoU[i],' acc:',accuracy[i])
 
+    return lossMeter.avg, mIoU, mAcc
+
 def train():
-    #device
-    device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-    model = fastscnn.FastSCNN(numClasses, True)
-    numParams = sum(torch.numel(p) for p in model.parameters() )
+    args = get_args()
+
+    if args.dist:
+        dist.init_process_group(backend='nccl')
+        local_rank = args.local_rank
+        torch.cuda.set_device(local_rank)
+        device = torch.device('cuda', local_rank)
+    else:
+        device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+
+    model = fastscnn.FastSCNN(args.num_classes, True)
+    numParams = sum(torch.numel(p) for p in model.parameters())
     print(f'Total paramers: {numParams}')
     model = model.to(device)
-    weightsInit(model)
-    mean,std = getMeanStd()
 
-    #criterion = nn.CrossEntropyLoss(ignore_index=255)
+    start_epoch = 1
+    optimizer = torch.optim.SGD(model.parameters(), lr=args.base_lr,
+                                momentum=args.momentum, weight_decay=args.weight_decay)
+
+    if args.resume:
+        if os.path.isfile(args.resume):
+            print(f'=> loading checkpoint: {args.resume}')
+            checkpoint = torch.load(args.resume, map_location=device)
+            start_epoch = checkpoint['epoch'] + 1
+            model.load_state_dict(checkpoint['state_dict'])
+            optimizer.load_state_dict(checkpoint['optimizer'])
+            print(f'=> resumed from epoch {checkpoint["epoch"]}')
+        else:
+            print(f'=> no checkpoint found at: {args.resume}')
+            weightsInit(model)
+    else:
+        weightsInit(model)
+
+    if args.dist:
+        model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[local_rank])
+    elif args.multigpu and torch.cuda.device_count() > 1:
+        print(f'Using {torch.cuda.device_count()} GPUs with DataParallel')
+        model = torch.nn.DataParallel(model)
+
     criterion = diceloss.DiceLoss()
-    optimizer = torch.optim.SGD(model.parameters(),lr=baseLr, momentum=0.9, weight_decay=0.0001)
+    mean, std = getMeanStd()
+    trainDataLoader, valDataLoader, train_sampler = prepareDataset(args, mean, std)
 
-    # get dataset
-    trainDataLoader, valDataLoader = prepareDataset(dataRoot, trainList, valList, mean, std)
+    maxIter = args.epochs * len(trainDataLoader)
 
-    # prepare something for learning rate
-    maxIter = globalEpoch * len(trainDataLoader)
+    is_main = (not args.dist) or (args.local_rank == 0)
+    writer = None
+    if is_main:
+        writer = SummaryWriter(log_dir=args.log_dir)
+        os.makedirs(args.save_dir, exist_ok=True)
 
-    # start training
-    for epoch in range(1, globalEpoch):
-        # do train on every epoch
-        subTrain(model, optimizer, criterion, trainDataLoader, epoch, maxIter, device)
-        # evaluate
-        subVal(model, criterion, valDataLoader, device)        
-        # save model
-        if ( (epoch) % 20) == 0:
-            filename = 'save/'+'train_'+str(epoch)+'.pth'
-            torch.save({'epoch':epoch, 'state_dict':model.state_dict(), 'optimizer':optimizer.state_dict()}, filename)
+    for epoch in range(start_epoch, args.epochs):
+        if args.dist and train_sampler is not None:
+            train_sampler.set_epoch(epoch)
+
+        train_loss, train_mIoU, train_mAcc = subTrain(
+            model, optimizer, criterion, trainDataLoader, epoch, maxIter, device, args)
+
+        val_loss, val_mIoU, val_mAcc = subVal(
+            model, criterion, valDataLoader, device, args)
+
+        if writer is not None:
+            writer.add_scalar('train/loss', train_loss, epoch)
+            writer.add_scalar('train/mIoU', train_mIoU, epoch)
+            writer.add_scalar('train/mAcc', train_mAcc, epoch)
+            writer.add_scalar('val/loss', val_loss, epoch)
+            writer.add_scalar('val/mIoU', val_mIoU, epoch)
+            writer.add_scalar('val/mAcc', val_mAcc, epoch)
+            writer.add_scalar('train/lr', optimizer.param_groups[0]['lr'], epoch)
+
+        if is_main and (epoch % args.save_freq) == 0:
+            state_dict = model.module.state_dict() if hasattr(model, 'module') else model.state_dict()
+            filename = os.path.join(args.save_dir, f'train_{epoch}.pth')
+            torch.save({
+                'epoch': epoch,
+                'state_dict': state_dict,
+                'optimizer': optimizer.state_dict(),
+                'args': vars(args)
+            }, filename)
+
+    if writer is not None:
+        writer.close()
+
+    if args.dist:
+        dist.destroy_process_group()
 
 
 if __name__ == '__main__':

--- a/utils/common.py
+++ b/utils/common.py
@@ -13,7 +13,7 @@ import torch
 from torch import nn
 
 
-def intersectionAndUnionGPU(output, target, K, ignore_index=255):
+def intersectionAndUnion(output, target, K, ignore_index=255):
     # 'K' classes, output and target sizes are N or N * L or N * H * W, each value in range 0 to K - 1.
     assert (output.dim() in [1, 2, 3])
     assert output.shape == target.shape
@@ -21,11 +21,14 @@ def intersectionAndUnionGPU(output, target, K, ignore_index=255):
     target = target.view(-1)
     output[target == ignore_index] = ignore_index
     intersection = output[output == target]
-    area_intersection = torch.histc(intersection.float().cpu(), bins=K, min=0, max=K-1) 
+    area_intersection = torch.histc(intersection.float().cpu(), bins=K, min=0, max=K-1)
     area_output = torch.histc(output.float().cpu(), bins=K, min=0, max=K-1)
     area_target = torch.histc(target.float().cpu(), bins=K, min=0, max=K-1)
     area_union = area_output + area_target - area_intersection
-    return area_intersection.cuda(), area_union.cuda(), area_target.cuda()
+    return area_intersection, area_union, area_target
+
+
+intersectionAndUnionGPU = intersectionAndUnion
 
 
 class AverageMeter(object):

--- a/utils/transform.py
+++ b/utils/transform.py
@@ -10,6 +10,7 @@ import math
 import numpy as np
 import cv2
 import collections
+import collections.abc
 import numbers
 
 from PIL import Image
@@ -71,7 +72,7 @@ class Normalize(object):
 class Resize(object):
     # Resize the input to the given size, 'size' is a 2-element tuple or list in the order of (h, w).
     def __init__(self, size):
-        assert (isinstance(size, collections.Iterable) and len(size) == 2)
+        assert (isinstance(size, collections.abc.Iterable) and len(size) == 2)
         self.size = size
 
     def __call__(self, image, label):
@@ -83,8 +84,8 @@ class Resize(object):
 class RandScale(object):
     # Randomly resize image & label with scale factor in [scale_min, scale_max]
     def __init__(self, scale, aspect_ratio=None):
-        assert (isinstance(scale, collections.Iterable) and len(scale) == 2)
-        if isinstance(scale, collections.Iterable) and len(scale) == 2 \
+        assert (isinstance(scale, collections.abc.Iterable) and len(scale) == 2)
+        if isinstance(scale, collections.abc.Iterable) and len(scale) == 2 \
                 and isinstance(scale[0], numbers.Number) and isinstance(scale[1], numbers.Number) \
                 and 0 < scale[0] < scale[1]:
             self.scale = scale
@@ -92,7 +93,7 @@ class RandScale(object):
             raise (RuntimeError("segtransform.RandScale() scale param error.\n"))
         if aspect_ratio is None:
             self.aspect_ratio = aspect_ratio
-        elif isinstance(aspect_ratio, collections.Iterable) and len(aspect_ratio) == 2 \
+        elif isinstance(aspect_ratio, collections.abc.Iterable) and len(aspect_ratio) == 2 \
                 and isinstance(aspect_ratio[0], numbers.Number) and isinstance(aspect_ratio[1], numbers.Number) \
                 and 0 < aspect_ratio[0] < aspect_ratio[1]:
             self.aspect_ratio = aspect_ratio
@@ -122,7 +123,7 @@ class Crop(object):
         if isinstance(size, int):
             self.crop_h = size
             self.crop_w = size
-        elif isinstance(size, collections.Iterable) and len(size) == 2 \
+        elif isinstance(size, collections.abc.Iterable) and len(size) == 2 \
                 and isinstance(size[0], int) and isinstance(size[1], int) \
                 and size[0] > 0 and size[1] > 0:
             self.crop_h = size[0]
@@ -175,7 +176,7 @@ class Crop(object):
 class RandRotate(object):
     # Randomly rotate image & label with rotate factor in [rotate_min, rotate_max]
     def __init__(self, rotate, padding, ignore_label=255, p=0.5):
-        assert (isinstance(rotate, collections.Iterable) and len(rotate) == 2)
+        assert (isinstance(rotate, collections.abc.Iterable) and len(rotate) == 2)
         if isinstance(rotate[0], numbers.Number) and isinstance(rotate[1], numbers.Number) and rotate[0] < rotate[1]:
             self.rotate = rotate
         else:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes all four TODO items from `readme.md`:

## Changes

### 1. TensorBoard logging (`tensorboardX`)
- Logs `train/loss`, `train/mIoU`, `train/mAcc`, `val/loss`, `val/mIoU`, `val/mAcc`, and `train/lr` every epoch
- Configurable log directory via `--log-dir` (default: `runs/`)
- Only writes from rank 0 in distributed mode

### 2. Resume training from checkpoint
- `--resume path/to/checkpoint.pth` restores epoch, model weights, and optimizer state
- Training continues from `checkpoint_epoch + 1`

### 3. VOC2012 dataset training script (argparse)
All hardcoded globals replaced with CLI arguments:
- `--data-root`, `--train-list`, `--val-list`, `--num-classes`
- `--epochs`, `--base-lr`, `--batch-size`, `--val-batch-size`
- `--input-h`, `--input-w`, `--num-workers`
- `--save-dir`, `--save-freq`, `--momentum`, `--weight-decay`, `--aux-weight`

### 4. Multi-GPU training
- `--multigpu`: wraps model in `nn.DataParallel`
- `--dist`: uses `DistributedDataParallel` with `DistributedSampler`, proper `set_epoch()`, and `model.module.state_dict()` for checkpoint saving

### Compatibility fixes
- `utils/transform.py`: `collections.Iterable` → `collections.abc.Iterable` (removed in Python 3.10)
- `utils/common.py`: `intersectionAndUnion` now returns CPU tensors instead of forcing `.cuda()`

## Testing

End-to-end training on dummy dataset (4 images, 4 classes, 64x64):

[e2e_training.log](https://cursor.com/agents/bc-7dae0b1a-fd89-4815-867d-9a55c5bf00ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_training.log)

Integration test suite (7/7 passing):

[test_results.log](https://cursor.com/agents/bc-7dae0b1a-fd89-4815-867d-9a55c5bf00ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dae0b1a-fd89-4815-867d-9a55c5bf00ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dae0b1a-fd89-4815-867d-9a55c5bf00ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

